### PR TITLE
Fixed updatedTranslate calculation.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -211,7 +211,7 @@ function InfinitePager(
     async (index: number, options: ImperativeApiOptions = {}) => {
       const layoutPageSize = await onLayoutPromise;
       const pSize = pageSize.value || layoutPageSize;
-      const updatedTranslate = index * pSize * -1;
+      const updatedTranslate = (index * pSize * -1) + (initialIndex*pSize);
 
       if (index < minIndex || index > maxIndex) return;
 


### PR DESCRIPTION
This is a fix to `updatedTranslate`
At the moment this variable is not correctly calculated when we enter a new view at a certain index.

If we have a normal view that has a button that opens up the InfinitePager component at a certain index, the current `updatedTranslate` doesn't take into consideration that we didn't start from index 0, therefore swiping afterwards becomes an issue.

This PR fixes that by adding `+ (initialIndex*pSize)` to the `updatedTranslate` variable in `setPage`