### PR TITLE
[BUGFIX] pageInterpolatorCube initialisation

### DIFF
--- a/src/pageInterpolators.ts
+++ b/src/pageInterpolators.ts
@@ -6,8 +6,6 @@ import {
 } from "react-native-reanimated";
 import { PageInterpolatorParams } from ".";
 
-export const defaultPageInterpolator = pageInterpolatorSlide;
-
 export function pageInterpolatorSlide({
   focusAnim,
   pageWidth,
@@ -189,3 +187,5 @@ export function pageInterpolatorTurnIn({
     ],
   };
 }
+
+export const defaultPageInterpolator = pageInterpolatorSlide;


### PR DESCRIPTION
### Description

This Pr includes:

1. Exporting `defaultPageInterpolator` after `pageInterpolatorSlide`

The bug was presented only in web environment